### PR TITLE
Hintergrundfarbe grau

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -3,6 +3,9 @@
    ============================== */
 
    * {box-sizing: border-box;}
+   body{
+     margin: 0;
+   }
    
 /* ============================== 
    CSS GRID
@@ -14,7 +17,7 @@
      grid-gap: 0;
    }
 
-/* Layout-Spalten Optik */
+/* Layout-Spalten Format */
 #left, #middle, #right {
        display: grid;
      }
@@ -33,4 +36,10 @@
 #right {
   grid-column: 10 / 13;
   grid-row: 1;
+  background-color: lightgrey;
+}
+
+/* Layout-Spalten Optik */
+#right {
+  background-color: lightgrey;
 }

--- a/src/style.css
+++ b/src/style.css
@@ -36,10 +36,9 @@
 #right {
   grid-column: 10 / 13;
   grid-row: 1;
-  background-color: lightgrey;
 }
 
 /* Layout-Spalten Optik */
 #right {
-  background-color: lightgrey;
+  background-color: rgb(139, 136, 136);
 }


### PR DESCRIPTION
Den margin habe ich auf 0 gesetzt, weil ich denke, dass kein weißer Rand die Hintergrundfarbe umschließen soll. Mir gefällt noch nicht, wie sich der Hintergrund bei kleinen Bildschirmen verhält. Sinnvoll wäre, wenn er beim Smartphone z. B. nach unten rücken würde. Bei Grid finde ich bisher nur den repeat(auto-fill), aber zufrieden stellt der mich nicht. Gibt es eine Alternative? Responsive Design ist vermutlich ein anderer Issue, deswegen requeste ich den hier trotzdem schon.